### PR TITLE
🎨 Fix overriding font styles

### DIFF
--- a/css/drizzle.css
+++ b/css/drizzle.css
@@ -395,12 +395,6 @@ pre {
   position: relative;
 }
 
-.drizzle-Layout-body,
-.drizzle-Item-notes p,
-.drizzle-Content-main > p {
-  font-family: sans-serif;
-}
-
 .drizzle-Content-main h1:not(:first-child),
 .drizzle-Content-main h2:not(:first-child),
 .drizzle-Content-main h3:not(:first-child),


### PR DESCRIPTION
Removes some leftovers from a previous take on the style updates that caused problems when setting a `font-family` on the `body`